### PR TITLE
chore: add JPA Auditing and BaseEntity configuration

### DIFF
--- a/src/main/kotlin/im/grit/infrastructure/common/entity/BaseDateTimeEntity.kt
+++ b/src/main/kotlin/im/grit/infrastructure/common/entity/BaseDateTimeEntity.kt
@@ -1,0 +1,31 @@
+package im.grit.infrastructure.common.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseDateTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false, comment = "생성 날짜")
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        protected set
+
+    @LastModifiedDate
+    @Column(nullable = false, comment = "최종 수정 날짜")
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+        protected set
+}

--- a/src/main/kotlin/im/grit/infrastructure/common/entity/BaseEntity.kt
+++ b/src/main/kotlin/im/grit/infrastructure/common/entity/BaseEntity.kt
@@ -1,0 +1,20 @@
+package im.grit.infrastructure.common.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.LastModifiedBy
+
+@MappedSuperclass
+abstract class BaseEntity : BaseDateTimeEntity() {
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false, comment = "생성한 사용자")
+    var createdBy: String = ""
+        protected set
+
+    @LastModifiedBy
+    @Column(nullable = false, comment = "최종 수정한 사용자")
+    var updatedBy: String = ""
+        protected set
+}

--- a/src/main/kotlin/im/grit/infrastructure/config/audit/AuditConfig.kt
+++ b/src/main/kotlin/im/grit/infrastructure/config/audit/AuditConfig.kt
@@ -1,0 +1,16 @@
+package im.grit.infrastructure.config.audit
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.domain.AuditorAware
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class AuditConfig {
+
+    @Bean
+    fun auditorAwareProvider(): AuditorAware<String> {
+        return AuditorAwareImpl()
+    }
+}

--- a/src/main/kotlin/im/grit/infrastructure/config/audit/AuditorAwareImpl.kt
+++ b/src/main/kotlin/im/grit/infrastructure/config/audit/AuditorAwareImpl.kt
@@ -1,0 +1,22 @@
+package im.grit.infrastructure.config.audit
+
+import org.springframework.data.domain.AuditorAware
+import org.springframework.security.authentication.AnonymousAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.*
+
+class AuditorAwareImpl : AuditorAware<String> {
+
+    override fun getCurrentAuditor(): Optional<String> {
+        val auditor = SecurityContextHolder.getContext().authentication
+            ?.takeIf { it.isAuthenticated && it !is AnonymousAuthenticationToken }
+            ?.name
+            ?: ANONYMOUS
+
+        return Optional.of(auditor)
+    }
+
+    companion object {
+        private const val ANONYMOUS = "anonymous"
+    }
+}


### PR DESCRIPTION
# 📋 Pull Request

## 📌 관련 이슈

#14 

## 📝 변경 사항 요약

엔티티 생성/수정 시간 및 사용자 자동 관리를 위한 JPA Auditing 설정

- @EnableJpaAuditing 활성화
- AuditorAware 구현 (Spring Security 연동)
- BaseTimeEntity 생성 (id, createdAt, updatedAt)
- BaseEntity 생성 (createdBy, updatedBy)

## 🔄 변경 유형

<!-- 해당하는 항목에 x 표시해주세요. (띄어쓰기 없이 [x]) -->

- [ ] 🐛 버그 수정 (Bug fix)
- [ ] ✨ 새 기능 (New feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🚀 성능 개선 (Performance improvement)
- [ ] 🧪 테스트 (Test)
- [ ] 📚 문서화 (Documentation)
- [x] 🔧 설정 변경 (Configuration change)
- [ ] 기타 (설명: )

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다

## 💬 기타

### 클래스 구조

| 클래스 | 필드 | 용도 |
|--------|------|------|
| BaseTimeEntity | id, createdAt, updatedAt | User 등 |
| BaseEntity | + createdBy, updatedBy | Mentoring, Review 등 |

### 사용 방법
```kotlin
// 시간만 필요한 경우 (User 등)
@Entity
class User(
    var name: String
) : BaseTimeEntity()

// 시간 + 작성자 필요한 경우 (Mentoring, Review 등)
@Entity
class Mentoring(
    var title: String
) : BaseEntity()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* 모든 데이터의 생성 시간과 최종 수정 시간이 자동으로 기록되어 정확한 변경 이력 추적이 가능합니다
* 데이터를 생성하고 수정하는 사용자 정보가 자동으로 기록되므로 각 변경에 대한 책임 추적이 가능합니다
* 완전한 감사 기반 구조를 통해 시스템의 데이터 무결성과 투명성이 강화되었습니다

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->